### PR TITLE
Updates Rolodex for Node v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "redis": "0.7.2",
     "connect": "2.6.0",
     "request": "2.11.4",
-    "bcrypt": "0.7.6",
+    "bcrypt": "0.8.3",
     "node-uuid": "1.3.1",
     "validator": "0.2.8",
     "thug": "0.4.2"


### PR DESCRIPTION
Updates bcrypt to the latest version, which makes all tests pass on Node v0.12.2.