### PR TITLE
Update rolodex.js to allow users to 

### DIFF
--- a/rolodex.js
+++ b/rolodex.js
@@ -1,7 +1,7 @@
 var redis   = require("redis")
 var request  = require("request")
 
-module.exports = function(options) {
+module.exports = function(options, redisClient) {
   if(!options) options = {}
 
   // TODO: improve this feedback message
@@ -96,7 +96,7 @@ module.exports = function(options) {
       user: "default",
       pass: "secret"
     }
-    var client = redis.createClient(options.redis)
+    var client = redisClient || redis.createClient(options.redis)
 
     rolodex.account = require("./models/account")({
       client: client,


### PR DESCRIPTION
The redis syntax is a bit strange, it allows us to set the port and host by using the overloaded constructor but not with the options params? Right now Rolodex only takes in a redis config so that means the user can't override the port / host to use a remote instance of redis.
https://www.npmjs.com/package/redis#redis-createclient

Not sure how you'd like the syntax for this, but I noticed that you had the following in server.js so it seems like you are looking for the redis client in the 2nd argument. 
```
var rolodex     = require("rolodex")({ "role": "master" }, redis)
```
